### PR TITLE
Further initial beta-fix

### DIFF
--- a/tsne.cpp
+++ b/tsne.cpp
@@ -404,7 +404,11 @@ static void computeGaussianPerplexity(double* X, int N, int D, double* P, double
 				else {
 					max_beta = beta;
 					if(min_beta == -DBL_MAX || min_beta == DBL_MAX)
-						beta /= 2.0;
+						if (beta < 0) 
+						      beta *= 2;
+						else 
+						      beta = beta <= 1.0 ? -0.5 : beta / 2.0;
+						    
 					else
 						beta = (beta + min_beta) / 2.0;
 				}


### PR DESCRIPTION
Previous attempt was also periodic in some cases where the set negative value was not small enough. This way negative values get doubled as initially intended by `beta /= 2`